### PR TITLE
Fixed 2 tests from lab 6 that Professor Baxter commented on.

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="14" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/tests/csc439team3/cardgame/ControllerTest.java
+++ b/tests/csc439team3/cardgame/ControllerTest.java
@@ -48,7 +48,6 @@ public class ControllerTest {
         controller.dealHand();
         //get the card to be swapped and then assert it has changed, and that a card has been discarded
         Card startCard = controller.players[0].hand.get(0);
-        if(startCard.isFaceDown()) startCard.flipCard();
         controller.getAction(controller.players[0]);
         assertThat(controller.players[0].hand.get(0)).isNotEqualTo(startCard);
         assertThat(controller.deck.discard.size()).isGreaterThan(0);
@@ -74,7 +73,6 @@ public class ControllerTest {
         //get the card at the top of the discard pile and then assert it is in player hand, and vice versa
         Card topOfDiscard = controller.deck.discard.get(0);
         Card playersFirstCard = controller.players[0].hand.get(0);
-        if(playersFirstCard.isFaceDown()) playersFirstCard.flipCard();
         controller.getAction(controller.players[0]);
         assertThat(controller.players[0].hand.get(0)).isEqualTo(topOfDiscard);
         assertThat(controller.deck.discard.get(0)).isEqualTo(playersFirstCard);

--- a/tests/csc439team3/cardgame/DeckTest.java
+++ b/tests/csc439team3/cardgame/DeckTest.java
@@ -1,7 +1,11 @@
 package csc439team3.cardgame;
 
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DeckTest {
@@ -20,8 +24,10 @@ public class DeckTest {
     @Test
     void shuffle(){
         Deck deck = new Deck(2);
+        Deck notShuffled = new Deck(2);
+        notShuffled.deck = (ArrayList<Card>) deck.deck.clone();
         deck.shuffle();
-        assertThat(deck.deck.get(0).printCard()).isNotEqualTo("A CLUB");
+        assertThat(deck.deck).isNotEqualTo(notShuffled.deck);
     }
 
 


### PR DESCRIPTION
The shuffle test asserted that the first card wouldn't be an Ace of Clubs but there is still a 1/52 chance this will fail. It was changed to clone the deck, shuffle it, then compare it to the unshuffled clone. 
Logic/if statements removed from a couple other tests where they were unnecessary in the first place as cards were being compared and did not need to be flipped in the context of those tests. 